### PR TITLE
add some intro styles for formatting examples

### DIFF
--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -1,3 +1,3 @@
 {{#each model as |movieRound|}}
-  <h1>{{movieRound.title}}</h1>
+  <h1 class="movie-title">{{movieRound.title}}</h1>
 {{/each}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,0 +1,8 @@
+// Movie Wager Application CSS
+//
+// This file will import all application styles
+
+@import 'base/variables';
+
+// routes
+@import 'routes/index';

--- a/app/styles/base/_variables.scss
+++ b/app/styles/base/_variables.scss
@@ -1,0 +1,11 @@
+// Colors
+// --------------------
+
+$white: #fff;
+$grey: #999;
+$black: #000;
+
+// Fonts
+// --------------------
+
+$helvetica: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;

--- a/app/styles/routes/_index.scss
+++ b/app/styles/routes/_index.scss
@@ -1,0 +1,4 @@
+.movie-title {
+  color: $grey;
+  font-family: $helvetica;
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.1.0",
     "ember-cli-release": "^0.2.9",
+    "ember-cli-sass": "5.6.0",
+    "ember-cli-sass-lint": "1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",


### PR DESCRIPTION
Just wanted to add some initial styles.

I'd like to take the approach of segregating our styles by routes or components just to keep it clean.  i.e. if you create an `admin` route, styles specific to that page should live in the `app/styles/routes` folder.  We will still have general styles used across our app, but that should be the template we try to follow.