### PR TITLE
add wager route and model

### DIFF
--- a/app/models/wager.js
+++ b/app/models/wager.js
@@ -1,0 +1,15 @@
+import DS from 'ember-data';
+
+const {
+  Model,
+  attr,
+  belongsTo
+} = DS;
+
+export default Model.extend({
+  user: belongsTo('user'),
+  movieRound: belongsTo('movie-round'),
+
+  amount: attr('number'),
+  place: attr('number')
+});

--- a/app/router.js
+++ b/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('admin');
   this.route('authenticated');
   this.route('sign-in');
+  this.route('wager', { path: 'wager/:movie_round_id' });
 });
 
 export default Router;

--- a/app/styles/routes/_admin.scss
+++ b/app/styles/routes/_admin.scss
@@ -1,6 +1,10 @@
 .form-container {
   width: 100%;
 
+  .form-header {
+    text-align: center;
+  }
+
   .movie-round-form {
     margin: auto;
     width: 50%;

--- a/app/wager/controller.js
+++ b/app/wager/controller.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+
+const {
+  Controller,
+  get,
+  inject: { service }
+} = Ember;
+
+export default Controller.extend({
+  flashMessages: service(),
+
+  actions: {
+    placeWager() {
+      let wager = get(this, 'wager');
+      let title = get(this, 'wager.movieRound.title');
+      let flashMessages = get(this, 'flashMessages');
+
+      wager.save().then(() => {
+        let amount = get(wager, 'amount');
+        flashMessages.success(`Bet placed for ${title} at ${amount}`);
+      }).catch(() => {
+        flashMessages.danger('Unable to place your bet. Please try again!');
+      });
+    }
+  }
+});

--- a/app/wager/route.js
+++ b/app/wager/route.js
@@ -1,0 +1,49 @@
+import Ember from 'ember';
+
+const {
+  Route,
+  RSVP,
+  get,
+  inject: { service },
+  set
+} = Ember;
+
+export default Route.extend({
+  flashMessages: service(),
+  session: service(),
+
+  model({ movie_round_id }) {
+    return this._createNewWager(movie_round_id);
+  },
+
+  setupController(controller, model) {
+    set(controller, 'wager', model);
+  },
+
+  _createNewWager(movie_round_id) {
+    return get(this, 'store').findRecord('movie-round', movie_round_id).then((movieRound) => {
+      return get(this, 'store').createRecord('wager', {
+        user: get(this, 'session').getUser(),
+        movieRound
+      });
+    }).catch(() => {
+      get(this, 'flashMessages').danger('Could not find that movie');
+      this.transitionTo('index');
+    });
+  },
+
+  actions: {
+    placeWager() {
+      let wager = get(this, 'controller.wager');
+      let title = get(this, 'controller.wager.movieRound.title');
+      let flashMessages = get(this, 'flashMessages');
+
+      wager.save().then((wager) => {
+        let amount = get(wager, 'amount');
+        flashMessages.success(`Bet placed for ${title} at ${amount}`);
+      }).catch(() => {
+        flashMessages.danger('Unable to place your bet. Please try again!');
+      });
+    }
+  }
+});

--- a/app/wager/route.js
+++ b/app/wager/route.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 
 const {
   Route,
-  RSVP,
   get,
   inject: { service },
   set
@@ -42,20 +41,5 @@ export default Route.extend({
     let user = get(this, 'session').getUser();
     let user_id = get(user, 'id');
     return get(this, 'store').query('wager', { user_id, movie_round_id });
-  },
-
-  actions: {
-    placeWager() {
-      let wager = get(this, 'controller.wager');
-      let title = get(this, 'controller.wager.movieRound.title');
-      let flashMessages = get(this, 'flashMessages');
-
-      wager.save().then(() => {
-        let amount = get(wager, 'amount');
-        flashMessages.success(`Bet placed for ${title} at ${amount}`);
-      }).catch(() => {
-        flashMessages.danger('Unable to place your bet. Please try again!');
-      });
-    }
   }
 });

--- a/app/wager/template.hbs
+++ b/app/wager/template.hbs
@@ -1,0 +1,11 @@
+<section class="form-container">
+  <h2 class="form-header">You're betting on: {{wager.movieRound.title}}</h2>
+  <form class="movie-round-form">
+    <label>
+      <span>Amount</span>
+      {{input class="input-text" type="number" value=wager.amount}}
+    </label>
+
+    <button type="submit" {{action (route-action "placeWager")}}>Submit</button>
+  </form>
+</section>

--- a/app/wager/template.hbs
+++ b/app/wager/template.hbs
@@ -6,6 +6,6 @@
       {{input class="input-text" type="number" value=wager.amount}}
     </label>
 
-    <button type="submit" {{action (route-action "placeWager")}}>Submit</button>
+    <button type="submit" {{action "placeWager"}}>Submit</button>
   </form>
 </section>

--- a/tests/unit/models/wager-test.js
+++ b/tests/unit/models/wager-test.js
@@ -1,12 +1,10 @@
 import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('wager', 'Unit | Model | wager', {
-  // Specify the other units that are required for this test.
-  needs: []
+  needs: ['model:user', 'model:movie-round']
 });
 
 test('it exists', function(assert) {
   let model = this.subject();
-  // let store = this.store();
   assert.ok(!!model);
 });

--- a/tests/unit/models/wager-test.js
+++ b/tests/unit/models/wager-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('wager', 'Unit | Model | wager', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/wager/controller-test.js
+++ b/tests/unit/wager/controller-test.js
@@ -1,0 +1,8 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:wager', 'Unit | Controller | wager');
+
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/wager/route-test.js
+++ b/tests/unit/wager/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:wager', 'Unit | Route | wager', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/wager/route-test.js
+++ b/tests/unit/wager/route-test.js
@@ -1,11 +1,39 @@
 import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
 
-moduleFor('route:wager', 'Unit | Route | wager', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+moduleFor('route:wager', 'Unit | Route | wager');
+
+function getPreviousStub(movie_round_id) {
+  return new Ember.RSVP.Promise((resolve) => {
+    if (movie_round_id === 1) {
+      resolve([{ foo: 'bar' }]);
+    } else {
+      resolve([]);
+    }
+  });
+}
+
+test('it properly sets wager on controller', function(assert) {
+  let route = this.subject();
+  let controller = {};
+
+  route.setupController(controller, 'foo');
+  assert.equal(controller.wager, 'foo');
 });
 
-test('it exists', function(assert) {
-  let route = this.subject();
-  assert.ok(route);
+test('it returns an existing wager if it exists', function(assert) {
+  let route = this.subject({ _getPreviousWagers: getPreviousStub });
+  route.model({ movie_round_id: 1 }).then((result) => {
+    assert.deepEqual(result, { foo: 'bar' }, 'existing wager is returned');
+  });
+});
+
+test('it creates a new wager when one is not found', function(assert) {
+  let route = this.subject({
+    _getPreviousWagers: getPreviousStub,
+    _createNewWager() {
+      assert.ok(true, 'new record is created');
+    }
+  });
+  route.model({ movie_round_id: 2 });
 });


### PR DESCRIPTION
This PR adds the front-end model for a "wager" as well as the initial route for placing a bet.

- [x] Relate wagers to user and move-round
- [x] Restrict wagers if no movie-round is found
- [ ] Restrict wagers if user is not logged in
- [x] Check to see if user has already placed a wager for this movie round
  - [x] If so, allow them to edit rather create new bet